### PR TITLE
Fix: Uncaught TypeError: trim() expects parameter 1 to be string (PluginUpdater)

### DIFF
--- a/Classes/Updates/PluginUpdater.php
+++ b/Classes/Updates/PluginUpdater.php
@@ -119,12 +119,12 @@ class PluginUpdater implements UpgradeWizardInterface
             if ($targetListType === '') {
                 continue;
             }
-            $allowedSettings = $this->getAllowedSettingsFromFlexForm($targetListType);
+            $allowedSettings = (!empty($targetListType)) ? $this->getAllowedSettingsFromFlexForm($targetListType) : [];
 
             // Remove flexform data which do not exist in flexform of new plugin
             foreach ($flexFormData['data'] as $sheetKey => $sheetData) {
                 foreach ($sheetData['lDEF'] as $settingName => $setting) {
-                    if (!in_array($settingName, $allowedSettings, true)) {
+                    if (sizeof($allowedSettings) && !in_array($settingName, $allowedSettings, true)) {
                         unset($flexFormData['data'][$sheetKey]['lDEF'][$settingName]);
                     }
                 }


### PR DESCRIPTION
Fatal error:  Uncaught TypeError: trim() expects parameter 1 to be string, null given in /shared/web/typo3conf/ext/news/Classes/Updates/PluginUpdater.php:181

